### PR TITLE
Handle fields wider than 24 characters

### DIFF
--- a/lastpass.el
+++ b/lastpass.el
@@ -448,15 +448,27 @@ As it uses message to print the password, it will be visible in the *Messages* b
   "Create a string with SPACES number of whitespaces."
   (mapconcat 'identity (make-list spaces " ") ""))
 
+(defsubst lastpass-pad-to-width (item width)
+  "Create a string with ITEM padded to WIDTH."
+  (if (= (length item) width)
+      item
+    (if (>= (length item) width)
+        (concat (substring item 0 (- width 1)) "…")
+      (concat item (lastpass-list-all-make-spaces (- width (length item)))))))
+
 (defsubst lastpass-list-all-make-element (item)
   "Create a new widget element from ITEM.
 Also update the `lastpass-group-completion' variable by adding groups to list."
   (let ((fields (split-string item lastpass-list-all-delimiter)))
     (add-to-list 'lastpass-group-completion (nth 2 fields))
     (cons (concat
-           (concat (nth 0 fields) (lastpass-list-all-make-spaces (- 24 (length (nth 0 fields)))))
-           (concat (nth 1 fields) (lastpass-list-all-make-spaces (- 24 (length (nth 1 fields)))))
-           (concat (nth 2 fields) (lastpass-list-all-make-spaces (- 24 (length (nth 2 fields)))))
+           (lastpass-pad-to-width (nth 0 fields) 24)
+           (lastpass-pad-to-width
+            (if (string-prefix-p "Generated Password for " (nth 1 fields))
+                (concat "…" (substring (nth 1 fields) 23))
+              (nth 1 fields))
+            24)
+           (lastpass-pad-to-width (nth 2 fields) 24)
            (nth 3 fields))
           (nth 0 fields))))
 


### PR DESCRIPTION
My lastpass vault contains several items that have fields, especially names, wider than 24 characters. This causes `lastpass-list-all-make-element` to send a negative number to `lastpas-list-all-make-spaces` and that ends badly. This PR:

1. Encapsulates "pad a field to a particular width" in `lastpass-pad-to-width`. A field is padded to the specified width or truncated with a horizontal ellipsis at the end if it's longer than the width.
2. Handles the special case of a name that begins "Generated Password for " by replacing that with a horizontal ellipsis. 